### PR TITLE
Quote surround I18n yes/no keys

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,8 +44,8 @@ en:
         confidential: 'Confidential?'
         actions: 'Actions'
         confidentiality:
-          yes: 'Yes'
-          no: 'No'
+          'yes': 'Yes'
+          'no': 'No'
       new:
         title: 'New Application'
       show:


### PR DESCRIPTION
`yes` & `no` are reserved key names as part of the yaml spec: http://yaml.org/refcard.html
When left unquoted, they act as booleans and can't be referenced using the key name.